### PR TITLE
Implemented Alternative Checkboxes Style Settings Toggle

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -603,6 +603,12 @@ settings:
         type: class-toggle
         default: false
     -
+        id: alternative-checkboxes
+        title: Use alternative checkboxes
+        description: Disable this if you are using your own implementation via a CSS Snippet.
+        default: true
+        type: class-toggle
+    -
       id: callout-emojis-heading
       title: Callouts with Emoji Support ✨
       type: heading
@@ -1778,90 +1784,90 @@ body.theme-dark.green-alternative-color {
 /* Support @colineckert - https://www.buymeacoffee.com/colineckert */
 /* ------------------- */
 
-input[data-task='!']:checked,
-input[data-task='*']:checked,
-input[data-task='-']:checked,
-input[data-task='<']:checked,
-input[data-task='>']:checked,
-input[data-task='I']:checked,
-input[data-task='b']:checked,
-input[data-task='c']:checked,
-input[data-task='d']:checked,
-input[data-task='f']:checked,
-input[data-task='k']:checked,
-input[data-task='l']:checked,
-input[data-task='p']:checked,
-input[data-task='u']:checked,
-input[data-task='w']:checked,
-input[data-task='P']:checked,
-input[data-task='M']:checked,
-input[data-task='D']:checked,
-input[data-task='m']:checked,
-input[data-task='h']:checked,
-input[data-task='a']:checked,
-input[data-task='e']:checked,
-input[data-task='s']:checked,
-input[data-task='r']:checked,
-input[data-task='8']:checked,
-input[data-task='+']:checked,
-input[data-task='n']:checked,
-input[data-task='g']:checked,
-li[data-task='!'] > input:checked,
-li[data-task='!'] > p > input:checked,
-li[data-task='*'] > input:checked,
-li[data-task='*'] > p > input:checked,
-li[data-task='-'] > input:checked,
-li[data-task='-'] > p > input:checked,
-li[data-task='<'] > input:checked,
-li[data-task='<'] > p > input:checked,
-li[data-task='>'] > input:checked,
-li[data-task='>'] > p > input:checked,
-li[data-task='I'] > input:checked,
-li[data-task='I'] > p > input:checked,
-li[data-task='b'] > input:checked,
-li[data-task='b'] > p > input:checked,
-li[data-task='c'] > input:checked,
-li[data-task='c'] > p > input:checked,
-li[data-task='d'] > input:checked,
-li[data-task='d'] > p > input:checked,
-li[data-task='f'] > input:checked,
-li[data-task='f'] > p > input:checked,
-li[data-task='k'] > input:checked,
-li[data-task='k'] > p > input:checked,
-li[data-task='l'] > input:checked,
-li[data-task='l'] > p > input:checked,
-li[data-task='p'] > input:checked,
-li[data-task='p'] > p > input:checked,
-li[data-task='u'] > input:checked,
-li[data-task='u'] > p > input:checked,
-li[data-task='w'] > input:checked,
-li[data-task='w'] > p > input:checked,
-li[data-task='P'] > input:checked,
-li[data-task='P'] > p > input:checked,
-li[data-task='M'] > input:checked,
-li[data-task='M'] > p > input:checked,
-li[data-task='D'] > input:checked,
-li[data-task='D'] > p > input:checked,
-li[data-task='m'] > input:checked,
-li[data-task='m'] > p > input:checked,
-li[data-task='h'] > input:checked,
-li[data-task='h'] > p > input:checked,
-li[data-task='a'] > input:checked,
-li[data-task='a'] > p > input:checked,
-li[data-task='e'] > input:checked,
-li[data-task='e'] > p > input:checked,
-li[data-task='s'] > input:checked,
-li[data-task='s'] > p > input:checked,
-li[data-task='r'] > input:checked,
-li[data-task='r'] > p > input:checked,
-li[data-task='8'] > input:checked,
-li[data-task='8'] > p > input:checked,
-li[data-task='+'] > input:checked,
-li[data-task='+'] > p > input:checked,
-li[data-task='n'] > input:checked,
-li[data-task='n'] > p > input:checked,
-li[data-task='g'] > input:checked,
-li[data-task='g'] > p > input:checked {
+body.alternative-checkboxes input[data-task='!']:checked,
+body.alternative-checkboxes input[data-task='*']:checked,
+body.alternative-checkboxes input[data-task='-']:checked,
+body.alternative-checkboxes input[data-task='<']:checked,
+body.alternative-checkboxes input[data-task='>']:checked,
+body.alternative-checkboxes input[data-task='I']:checked,
+body.alternative-checkboxes input[data-task='b']:checked,
+body.alternative-checkboxes input[data-task='c']:checked,
+body.alternative-checkboxes input[data-task='d']:checked,
+body.alternative-checkboxes input[data-task='f']:checked,
+body.alternative-checkboxes input[data-task='k']:checked,
+body.alternative-checkboxes input[data-task='l']:checked,
+body.alternative-checkboxes input[data-task='p']:checked,
+body.alternative-checkboxes input[data-task='u']:checked,
+body.alternative-checkboxes input[data-task='w']:checked,
+body.alternative-checkboxes input[data-task='P']:checked,
+body.alternative-checkboxes input[data-task='M']:checked,
+body.alternative-checkboxes input[data-task='D']:checked,
+body.alternative-checkboxes input[data-task='m']:checked,
+body.alternative-checkboxes input[data-task='h']:checked,
+body.alternative-checkboxes input[data-task='a']:checked,
+body.alternative-checkboxes input[data-task='e']:checked,
+body.alternative-checkboxes input[data-task='s']:checked,
+body.alternative-checkboxes input[data-task='r']:checked,
+body.alternative-checkboxes input[data-task='8']:checked,
+body.alternative-checkboxes input[data-task='+']:checked,
+body.alternative-checkboxes input[data-task='n']:checked,
+body.alternative-checkboxes input[data-task='g']:checked,
+body.alternative-checkboxes li[data-task='!'] > input:checked,
+body.alternative-checkboxes li[data-task='!'] > p > input:checked,
+body.alternative-checkboxes li[data-task='*'] > input:checked,
+body.alternative-checkboxes li[data-task='*'] > p > input:checked,
+body.alternative-checkboxes li[data-task='-'] > input:checked,
+body.alternative-checkboxes li[data-task='-'] > p > input:checked,
+body.alternative-checkboxes li[data-task='<'] > input:checked,
+body.alternative-checkboxes li[data-task='<'] > p > input:checked,
+body.alternative-checkboxes li[data-task='>'] > input:checked,
+body.alternative-checkboxes li[data-task='>'] > p > input:checked,
+body.alternative-checkboxes li[data-task='I'] > input:checked,
+body.alternative-checkboxes li[data-task='I'] > p > input:checked,
+body.alternative-checkboxes li[data-task='b'] > input:checked,
+body.alternative-checkboxes li[data-task='b'] > p > input:checked,
+body.alternative-checkboxes li[data-task='c'] > input:checked,
+body.alternative-checkboxes li[data-task='c'] > p > input:checked,
+body.alternative-checkboxes li[data-task='d'] > input:checked,
+body.alternative-checkboxes li[data-task='d'] > p > input:checked,
+body.alternative-checkboxes li[data-task='f'] > input:checked,
+body.alternative-checkboxes li[data-task='f'] > p > input:checked,
+body.alternative-checkboxes li[data-task='k'] > input:checked,
+body.alternative-checkboxes li[data-task='k'] > p > input:checked,
+body.alternative-checkboxes li[data-task='l'] > input:checked,
+body.alternative-checkboxes li[data-task='l'] > p > input:checked,
+body.alternative-checkboxes li[data-task='p'] > input:checked,
+body.alternative-checkboxes li[data-task='p'] > p > input:checked,
+body.alternative-checkboxes li[data-task='u'] > input:checked,
+body.alternative-checkboxes li[data-task='u'] > p > input:checked,
+body.alternative-checkboxes li[data-task='w'] > input:checked,
+body.alternative-checkboxes li[data-task='w'] > p > input:checked,
+body.alternative-checkboxes li[data-task='P'] > input:checked,
+body.alternative-checkboxes li[data-task='P'] > p > input:checked,
+body.alternative-checkboxes li[data-task='M'] > input:checked,
+body.alternative-checkboxes li[data-task='M'] > p > input:checked,
+body.alternative-checkboxes li[data-task='D'] > input:checked,
+body.alternative-checkboxes li[data-task='D'] > p > input:checked,
+body.alternative-checkboxes li[data-task='m'] > input:checked,
+body.alternative-checkboxes li[data-task='m'] > p > input:checked,
+body.alternative-checkboxes li[data-task='h'] > input:checked,
+body.alternative-checkboxes li[data-task='h'] > p > input:checked,
+body.alternative-checkboxes li[data-task='a'] > input:checked,
+body.alternative-checkboxes li[data-task='a'] > p > input:checked,
+body.alternative-checkboxes li[data-task='e'] > input:checked,
+body.alternative-checkboxes li[data-task='e'] > p > input:checked,
+body.alternative-checkboxes li[data-task='s'] > input:checked,
+body.alternative-checkboxes li[data-task='s'] > p > input:checked,
+body.alternative-checkboxes li[data-task='r'] > input:checked,
+body.alternative-checkboxes li[data-task='r'] > p > input:checked,
+body.alternative-checkboxes li[data-task='8'] > input:checked,
+body.alternative-checkboxes li[data-task='8'] > p > input:checked,
+body.alternative-checkboxes li[data-task='+'] > input:checked,
+body.alternative-checkboxes li[data-task='+'] > p > input:checked,
+body.alternative-checkboxes li[data-task='n'] > input:checked,
+body.alternative-checkboxes li[data-task='n'] > p > input:checked,
+body.alternative-checkboxes li[data-task='g'] > input:checked,
+body.alternative-checkboxes li[data-task='g'] > p > input:checked {
   --checkbox-marker-color: transparent;
   border: none;
   border-radius: 0;
@@ -1873,9 +1879,9 @@ li[data-task='g'] > p > input:checked {
   mask-position: 50% 50%;
 
 }
-input[data-task='>']:checked,
-li[data-task='>'] > input:checked,
-li[data-task='>'] > p > input:checked {
+body.alternative-checkboxes input[data-task='>']:checked,
+body.alternative-checkboxes li[data-task='>'] > input:checked,
+body.alternative-checkboxes li[data-task='>'] > p > input:checked {
   color: var(--text-faint);
   transform: rotate(90deg);
   -webkit-mask-position: 50% 100%;
@@ -1883,18 +1889,18 @@ li[data-task='>'] > p > input:checked {
   mask-position: 50% 100%;
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath d='M10.894 2.553a1 1 0 00-1.788 0l-7 14a1 1 0 001.169 1.409l5-1.429A1 1 0 009 15.571V11a1 1 0 112 0v4.571a1 1 0 00.725.962l5 1.428a1 1 0 001.17-1.408l-7-14z' /%3E%3C/svg%3E");
 }
-input[data-task='<']:checked,
-li[data-task='<'] > input:checked,
-li[data-task='<'] > p > input:checked {
+body.alternative-checkboxes input[data-task='<']:checked,
+body.alternative-checkboxes li[data-task='<'] > input:checked,
+body.alternative-checkboxes li[data-task='<'] > p > input:checked {
   color: var(--text-faint);
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath fill-rule='evenodd' d='M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z' clip-rule='evenodd' /%3E%3C/svg%3E");
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath fill-rule='evenodd' d='M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z' clip-rule='evenodd' /%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath fill-rule='evenodd' d='M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z' clip-rule='evenodd' /%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath fill-rule='evenodd' d='M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z' clip-rule='evenodd' /%3E%3C/svg%3E");
 }
-input[data-task='?']:checked,
-li[data-task='?'] > input:checked,
-li[data-task='?'] > p > input:checked {
+body.alternative-checkboxes input[data-task='?']:checked,
+body.alternative-checkboxes li[data-task='?'] > input:checked,
+body.alternative-checkboxes li[data-task='?'] > p > input:checked {
   --checkbox-marker-color: transparent;
   background-color: var(--color-yellow);
   border-color: var(--color-yellow);
@@ -1902,22 +1908,22 @@ li[data-task='?'] > p > input:checked {
   background-size: 200% 90%;
   background-image: url('data:image/svg+xml,%3Csvg xmlns="http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg" width="20" height="20" preserveAspectRatio="xMidYMid meet" viewBox="0 0 16 16"%3E%3Cpath fill="white" fill-rule="evenodd" d="M4.475 5.458c-.284 0-.514-.237-.47-.517C4.28 3.24 5.576 2 7.825 2c2.25 0 3.767 1.36 3.767 3.215c0 1.344-.665 2.288-1.79 2.973c-1.1.659-1.414 1.118-1.414 2.01v.03a.5.5 0 0 1-.5.5h-.77a.5.5 0 0 1-.5-.495l-.003-.2c-.043-1.221.477-2.001 1.645-2.712c1.03-.632 1.397-1.135 1.397-2.028c0-.979-.758-1.698-1.926-1.698c-1.009 0-1.71.529-1.938 1.402c-.066.254-.278.461-.54.461h-.777ZM7.496 14c.622 0 1.095-.474 1.095-1.09c0-.618-.473-1.092-1.095-1.092c-.606 0-1.087.474-1.087 1.091S6.89 14 7.496 14Z"%2F%3E%3C%2Fsvg%3E');
 }
-.theme-dark input[data-task='?']:checked,
-.theme-dark li[data-task='?'] > input:checked,
-.theme-dark li[data-task='?'] > p > input:checked {
+body.alternative-checkboxes.theme-dark input[data-task='?']:checked,
+body.alternative-checkboxes.theme-dark li[data-task='?'] > input:checked,
+body.alternative-checkboxes.theme-dark li[data-task='?'] > p > input:checked {
   background-image: url('data:image/svg+xml,%3Csvg xmlns="http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg" width="20" height="20" preserveAspectRatio="xMidYMid meet" viewBox="0 0 16 16"%3E%3Cpath fill="black" fill-opacity="0.8" fill-rule="evenodd" d="M4.475 5.458c-.284 0-.514-.237-.47-.517C4.28 3.24 5.576 2 7.825 2c2.25 0 3.767 1.36 3.767 3.215c0 1.344-.665 2.288-1.79 2.973c-1.1.659-1.414 1.118-1.414 2.01v.03a.5.5 0 0 1-.5.5h-.77a.5.5 0 0 1-.5-.495l-.003-.2c-.043-1.221.477-2.001 1.645-2.712c1.03-.632 1.397-1.135 1.397-2.028c0-.979-.758-1.698-1.926-1.698c-1.009 0-1.71.529-1.938 1.402c-.066.254-.278.461-.54.461h-.777ZM7.496 14c.622 0 1.095-.474 1.095-1.09c0-.618-.473-1.092-1.095-1.092c-.606 0-1.087.474-1.087 1.091S6.89 14 7.496 14Z"%2F%3E%3C%2Fsvg%3E');
 }
-input[data-task='/']:checked,
-li[data-task='/'] > input:checked,
-li[data-task='/'] > p > input:checked {
+body.alternative-checkboxes input[data-task='/']:checked,
+body.alternative-checkboxes li[data-task='/'] > input:checked,
+body.alternative-checkboxes li[data-task='/'] > p > input:checked {
   background-image: none;
   background-color: transparent;
   position: relative;
   overflow: hidden;
 }
-input[data-task='/']:checked:after,
-li[data-task='/'] > input:checked:after,
-li[data-task='/'] > p > input:checked:after {
+body.alternative-checkboxes input[data-task='/']:checked:after,
+body.alternative-checkboxes li[data-task='/'] > input:checked:after,
+body.alternative-checkboxes li[data-task='/'] > p > input:checked:after {
   top: 0;
   left: 0;
   content: ' ';
@@ -1929,19 +1935,19 @@ li[data-task='/'] > p > input:checked:after {
   -webkit-mask-image: none;
   mask-image: none;
 }
-input[data-task='!']:checked,
-li[data-task='!'] > input:checked,
-li[data-task='!'] > p > input:checked {
+body.alternative-checkboxes input[data-task='!']:checked,
+body.alternative-checkboxes li[data-task='!'] > input:checked,
+body.alternative-checkboxes li[data-task='!'] > p > input:checked {
   color: var(--color-orange);
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath fill-rule='evenodd' d='M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z' clip-rule='evenodd' /%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath fill-rule='evenodd' d='M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z' clip-rule='evenodd' /%3E%3C/svg%3E");
 }
-input[data-task='"']:checked,
-input[data-task='“']:checked,
-li[data-task='"'] > input:checked,
-li[data-task='"'] > p > input:checked,
-li[data-task='“'] > input:checked,
-li[data-task='“'] > p > input:checked {
+body.alternative-checkboxes input[data-task='"']:checked,
+body.alternative-checkboxes input[data-task='“']:checked,
+body.alternative-checkboxes li[data-task='"'] > input:checked,
+body.alternative-checkboxes li[data-task='"'] > p > input:checked,
+body.alternative-checkboxes li[data-task='“'] > input:checked,
+body.alternative-checkboxes li[data-task='“'] > p > input:checked {
   --checkbox-marker-color: transparent;
   background-position: 50% 50%;
   background-color: var(--color-cyan);
@@ -1950,49 +1956,44 @@ li[data-task='“'] > p > input:checked {
   background-repeat: no-repeat;
   background-image: url('data:image/svg+xml,%3Csvg xmlns="http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg" width="20" height="20" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24"%3E%3Cpath fill="white" d="M6.5 10c-.223 0-.437.034-.65.065c.069-.232.14-.468.254-.68c.114-.308.292-.575.469-.844c.148-.291.409-.488.601-.737c.201-.242.475-.403.692-.604c.213-.21.492-.315.714-.463c.232-.133.434-.28.65-.35l.539-.222l.474-.197l-.485-1.938l-.597.144c-.191.048-.424.104-.689.171c-.271.05-.56.187-.882.312c-.318.142-.686.238-1.028.466c-.344.218-.741.4-1.091.692c-.339.301-.748.562-1.05.945c-.33.358-.656.734-.909 1.162c-.293.408-.492.856-.702 1.299c-.19.443-.343.896-.468 1.336c-.237.882-.343 1.72-.384 2.437c-.034.718-.014 1.315.028 1.747c.015.204.043.402.063.539l.025.168l.026-.006A4.5 4.5 0 1 0 6.5 10zm11 0c-.223 0-.437.034-.65.065c.069-.232.14-.468.254-.68c.114-.308.292-.575.469-.844c.148-.291.409-.488.601-.737c.201-.242.475-.403.692-.604c.213-.21.492-.315.714-.463c.232-.133.434-.28.65-.35l.539-.222l.474-.197l-.485-1.938l-.597.144c-.191.048-.424.104-.689.171c-.271.05-.56.187-.882.312c-.317.143-.686.238-1.028.467c-.344.218-.741.4-1.091.692c-.339.301-.748.562-1.05.944c-.33.358-.656.734-.909 1.162c-.293.408-.492.856-.702 1.299c-.19.443-.343.896-.468 1.336c-.237.882-.343 1.72-.384 2.437c-.034.718-.014 1.315.028 1.747c.015.204.043.402.063.539l.025.168l.026-.006A4.5 4.5 0 1 0 17.5 10z"%2F%3E%3C%2Fsvg%3E');
 }
-.theme-dark input[data-task='"']:checked,
-.theme-dark input[data-task='“']:checked,
-.theme-dark li[data-task='"'] > input:checked,
-.theme-dark li[data-task='"'] > p > input:checked,
-.theme-dark li[data-task='“'] > input:checked,
-.theme-dark li[data-task='“'] > p > input:checked {
+body.alternative-checkboxes.theme-dark input[data-task='"']:checked,
+body.alternative-checkboxes.theme-dark input[data-task='“']:checked,
+body.alternative-checkboxes.theme-dark li[data-task='"'] > input:checked,
+body.alternative-checkboxes.theme-dark li[data-task='"'] > p > input:checked,
+body.alternative-checkboxes.theme-dark li[data-task='“'] > input:checked,
+body.alternative-checkboxes.theme-dark li[data-task='“'] > p > input:checked {
   background-image: url('data:image/svg+xml,%3Csvg xmlns="http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg" width="20" height="20" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24"%3E%3Cpath fill="black" fill-opacity="0.7" d="M6.5 10c-.223 0-.437.034-.65.065c.069-.232.14-.468.254-.68c.114-.308.292-.575.469-.844c.148-.291.409-.488.601-.737c.201-.242.475-.403.692-.604c.213-.21.492-.315.714-.463c.232-.133.434-.28.65-.35l.539-.222l.474-.197l-.485-1.938l-.597.144c-.191.048-.424.104-.689.171c-.271.05-.56.187-.882.312c-.318.142-.686.238-1.028.466c-.344.218-.741.4-1.091.692c-.339.301-.748.562-1.05.945c-.33.358-.656.734-.909 1.162c-.293.408-.492.856-.702 1.299c-.19.443-.343.896-.468 1.336c-.237.882-.343 1.72-.384 2.437c-.034.718-.014 1.315.028 1.747c.015.204.043.402.063.539l.025.168l.026-.006A4.5 4.5 0 1 0 6.5 10zm11 0c-.223 0-.437.034-.65.065c.069-.232.14-.468.254-.68c.114-.308.292-.575.469-.844c.148-.291.409-.488.601-.737c.201-.242.475-.403.692-.604c.213-.21.492-.315.714-.463c.232-.133.434-.28.65-.35l.539-.222l.474-.197l-.485-1.938l-.597.144c-.191.048-.424.104-.689.171c-.271.05-.56.187-.882.312c-.317.143-.686.238-1.028.467c-.344.218-.741.4-1.091.692c-.339.301-.748.562-1.05.944c-.33.358-.656.734-.909 1.162c-.293.408-.492.856-.702 1.299c-.19.443-.343.896-.468 1.336c-.237.882-.343 1.72-.384 2.437c-.034.718-.014 1.315.028 1.747c.015.204.043.402.063.539l.025.168l.026-.006A4.5 4.5 0 1 0 17.5 10z"%2F%3E%3C%2Fsvg%3E');
 }
-input[data-task='-']:checked,
-li[data-task='-'] > input:checked,
-li[data-task='-'] > p > input:checked {
+body.alternative-checkboxes input[data-task='-']:checked,
+body.alternative-checkboxes li[data-task='-'] > input:checked,
+body.alternative-checkboxes li[data-task='-'] > p > input:checked {
   color: var(--text-faint);
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath fill-rule='evenodd' d='M3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z' clip-rule='evenodd' /%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath fill-rule='evenodd' d='M3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z' clip-rule='evenodd' /%3E%3C/svg%3E");
 }
-body:not(.tasks)
-  .markdown-preview-view
-  ul
-  li[data-task='-'].task-list-item.is-checked,
-body:not(.tasks)
-  .markdown-source-view.mod-cm6
-  .HyperMD-task-line[data-task]:is([data-task='-']),
-body:not(.tasks) li[data-task='-'].task-list-item.is-checked {
+body.alternative-checkboxes:not(.tasks) .markdown-preview-view ul li[data-task='-'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) .markdown-source-view.mod-cm6 .HyperMD-task-line[data-task]:is([data-task='-']),
+body.alternative-checkboxes:not(.tasks) li[data-task='-'].task-list-item.is-checked {
   color: var(--text-faint);
   text-decoration: line-through solid var(--text-faint) 1px;
 }
-input[data-task='*']:checked,
-li[data-task='*'] > input:checked,
-li[data-task='*'] > p > input:checked {
+body.alternative-checkboxes input[data-task='*']:checked,
+body.alternative-checkboxes li[data-task='*'] > input:checked,
+body.alternative-checkboxes li[data-task='*'] > p > input:checked {
   color: var(--color-yellow);
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath d='M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z' /%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath d='M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z' /%3E%3C/svg%3E");
 }
-input[data-task='l']:checked,
-li[data-task='l'] > input:checked,
-li[data-task='l'] > p > input:checked {
+body.alternative-checkboxes input[data-task='l']:checked,
+body.alternative-checkboxes li[data-task='l'] > input:checked,
+body.alternative-checkboxes li[data-task='l'] > p > input:checked {
   color: var(--color-red);
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath fill-rule='evenodd' d='M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z' clip-rule='evenodd' /%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath fill-rule='evenodd' d='M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z' clip-rule='evenodd' /%3E%3C/svg%3E");
 }
-input[data-task='i']:checked,
-li[data-task='i'] > input:checked,
-li[data-task='i'] > p > input:checked {
+body.alternative-checkboxes input[data-task='i']:checked,
+body.alternative-checkboxes li[data-task='i'] > input:checked,
+body.alternative-checkboxes li[data-task='i'] > p > input:checked {
   --checkbox-marker-color: transparent;
   background-color: var(--color-blue);
   border-color: var(--color-blue);
@@ -2000,178 +2001,178 @@ li[data-task='i'] > p > input:checked {
   background-size: 100%;
   background-image: url('data:image/svg+xml,%3Csvg xmlns="http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg" width="20" height="20" preserveAspectRatio="xMidYMid meet" viewBox="0 0 512 512"%3E%3Cpath fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="40" d="M196 220h64v172"%2F%3E%3Cpath fill="none" stroke="white" stroke-linecap="round" stroke-miterlimit="10" stroke-width="40" d="M187 396h138"%2F%3E%3Cpath fill="white" d="M256 160a32 32 0 1 1 32-32a32 32 0 0 1-32 32Z"%2F%3E%3C%2Fsvg%3E');
 }
-.theme-dark input[data-task='i']:checked,
-.theme-dark li[data-task='i'] > input:checked,
-.theme-dark li[data-task='i'] > p > input:checked {
+body.alternative-checkboxes.theme-dark input[data-task='i']:checked,
+body.alternative-checkboxes.theme-dark li[data-task='i'] > input:checked,
+body.alternative-checkboxes.theme-dark li[data-task='i'] > p > input:checked {
   background-image: url('data:image/svg+xml,%3Csvg xmlns="http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg" width="20" height="20" preserveAspectRatio="xMidYMid meet" viewBox="0 0 512 512"%3E%3Cpath fill="none" stroke="black" stroke-opacity="0.8" stroke-linecap="round" stroke-linejoin="round" stroke-width="40" d="M196 220h64v172"%2F%3E%3Cpath fill="none" stroke="black" stroke-opacity="0.8" stroke-linecap="round" stroke-miterlimit="10" stroke-width="40" d="M187 396h138"%2F%3E%3Cpath fill="black" fill-opacity="0.8" d="M256 160a32 32 0 1 1 32-32a32 32 0 0 1-32 32Z"%2F%3E%3C%2Fsvg%3E');
 }
-input[data-task='S']:checked,
-li[data-task='S'] > input:checked,
-li[data-task='S'] > p > input:checked {
+body.alternative-checkboxes input[data-task='S']:checked,
+body.alternative-checkboxes li[data-task='S'] > input:checked,
+body.alternative-checkboxes li[data-task='S'] > p > input:checked {
   --checkbox-marker-color: transparent;
   border-color: var(--color-green);
   background-color: var(--color-green);
   background-size: 100%;
   background-image: url('data:image/svg+xml,%3Csvg xmlns="http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg" width="20" height="20" preserveAspectRatio="xMidYMid meet" viewBox="0 0 48 48"%3E%3Cpath fill="white" fill-rule="evenodd" d="M26 8a2 2 0 1 0-4 0v2a8 8 0 1 0 0 16v8a4.002 4.002 0 0 1-3.773-2.666a2 2 0 0 0-3.771 1.332A8.003 8.003 0 0 0 22 38v2a2 2 0 1 0 4 0v-2a8 8 0 1 0 0-16v-8a4.002 4.002 0 0 1 3.773 2.666a2 2 0 0 0 3.771-1.332A8.003 8.003 0 0 0 26 10V8Zm-4 6a4 4 0 0 0 0 8v-8Zm4 12v8a4 4 0 0 0 0-8Z" clip-rule="evenodd"%2F%3E%3C%2Fsvg%3E');
 }
-.theme-dark input[data-task='S']:checked,
-.theme-dark li[data-task='S'] > input:checked,
-.theme-dark li[data-task='S'] > p > input:checked {
+body.alternative-checkboxes.theme-dark input[data-task='S']:checked,
+body.alternative-checkboxes.theme-dark li[data-task='S'] > input:checked,
+body.alternative-checkboxes.theme-dark li[data-task='S'] > p > input:checked {
   background-image: url('data:image/svg+xml,%3Csvg xmlns="http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg" width="20" height="20" preserveAspectRatio="xMidYMid meet" viewBox="0 0 48 48"%3E%3Cpath fill-opacity="0.8" fill="black" fill-rule="evenodd" d="M26 8a2 2 0 1 0-4 0v2a8 8 0 1 0 0 16v8a4.002 4.002 0 0 1-3.773-2.666a2 2 0 0 0-3.771 1.332A8.003 8.003 0 0 0 22 38v2a2 2 0 1 0 4 0v-2a8 8 0 1 0 0-16v-8a4.002 4.002 0 0 1 3.773 2.666a2 2 0 0 0 3.771-1.332A8.003 8.003 0 0 0 26 10V8Zm-4 6a4 4 0 0 0 0 8v-8Zm4 12v8a4 4 0 0 0 0-8Z" clip-rule="evenodd"%2F%3E%3C%2Fsvg%3E');
 }
-input[data-task='I']:checked,
-li[data-task='I'] > input:checked,
-li[data-task='I'] > p > input:checked {
+body.alternative-checkboxes input[data-task='I']:checked,
+body.alternative-checkboxes li[data-task='I'] > input:checked,
+body.alternative-checkboxes li[data-task='I'] > p > input:checked {
   color: var(--color-yellow);
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath d='M11 3a1 1 0 10-2 0v1a1 1 0 102 0V3zM15.657 5.757a1 1 0 00-1.414-1.414l-.707.707a1 1 0 001.414 1.414l.707-.707zM18 10a1 1 0 01-1 1h-1a1 1 0 110-2h1a1 1 0 011 1zM5.05 6.464A1 1 0 106.464 5.05l-.707-.707a1 1 0 00-1.414 1.414l.707.707zM5 10a1 1 0 01-1 1H3a1 1 0 110-2h1a1 1 0 011 1zM8 16v-1h4v1a2 2 0 11-4 0zM12 14c.015-.34.208-.646.477-.859a4 4 0 10-4.954 0c.27.213.462.519.476.859h4.002z' /%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath d='M11 3a1 1 0 10-2 0v1a1 1 0 102 0V3zM15.657 5.757a1 1 0 00-1.414-1.414l-.707.707a1 1 0 001.414 1.414l.707-.707zM18 10a1 1 0 01-1 1h-1a1 1 0 110-2h1a1 1 0 011 1zM5.05 6.464A1 1 0 106.464 5.05l-.707-.707a1 1 0 00-1.414 1.414l.707.707zM5 10a1 1 0 01-1 1H3a1 1 0 110-2h1a1 1 0 011 1zM8 16v-1h4v1a2 2 0 11-4 0zM12 14c.015-.34.208-.646.477-.859a4 4 0 10-4.954 0c.27.213.462.519.476.859h4.002z' /%3E%3C/svg%3E");
 }
-input[data-task='f']:checked,
-li[data-task='f'] > input:checked,
-li[data-task='f'] > p > input:checked {
+body.alternative-checkboxes input[data-task='f']:checked,
+body.alternative-checkboxes li[data-task='f'] > input:checked,
+body.alternative-checkboxes li[data-task='f'] > p > input:checked {
   color: var(--color-red);
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath fill-rule='evenodd' d='M12.395 2.553a1 1 0 00-1.45-.385c-.345.23-.614.558-.822.88-.214.33-.403.713-.57 1.116-.334.804-.614 1.768-.84 2.734a31.365 31.365 0 00-.613 3.58 2.64 2.64 0 01-.945-1.067c-.328-.68-.398-1.534-.398-2.654A1 1 0 005.05 6.05 6.981 6.981 0 003 11a7 7 0 1011.95-4.95c-.592-.591-.98-.985-1.348-1.467-.363-.476-.724-1.063-1.207-2.03zM12.12 15.12A3 3 0 017 13s.879.5 2.5.5c0-1 .5-4 1.25-4.5.5 1 .786 1.293 1.371 1.879A2.99 2.99 0 0113 13a2.99 2.99 0 01-.879 2.121z' clip-rule='evenodd' /%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath fill-rule='evenodd' d='M12.395 2.553a1 1 0 00-1.45-.385c-.345.23-.614.558-.822.88-.214.33-.403.713-.57 1.116-.334.804-.614 1.768-.84 2.734a31.365 31.365 0 00-.613 3.58 2.64 2.64 0 01-.945-1.067c-.328-.68-.398-1.534-.398-2.654A1 1 0 005.05 6.05 6.981 6.981 0 003 11a7 7 0 1011.95-4.95c-.592-.591-.98-.985-1.348-1.467-.363-.476-.724-1.063-1.207-2.03zM12.12 15.12A3 3 0 017 13s.879.5 2.5.5c0-1 .5-4 1.25-4.5.5 1 .786 1.293 1.371 1.879A2.99 2.99 0 0113 13a2.99 2.99 0 01-.879 2.121z' clip-rule='evenodd' /%3E%3C/svg%3E");
 }
-input[data-task='k']:checked,
-li[data-task='k'] > input:checked,
-li[data-task='k'] > p > input:checked {
+body.alternative-checkboxes input[data-task='k']:checked,
+body.alternative-checkboxes li[data-task='k'] > input:checked,
+body.alternative-checkboxes li[data-task='k'] > p > input:checked {
   color: var(--color-yellow);
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath fill-rule='evenodd' d='M18 8a6 6 0 01-7.743 5.743L10 14l-1 1-1 1H6v2H2v-4l4.257-4.257A6 6 0 1118 8zm-6-4a1 1 0 100 2 2 2 0 012 2 1 1 0 102 0 4 4 0 00-4-4z' clip-rule='evenodd' /%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath fill-rule='evenodd' d='M18 8a6 6 0 01-7.743 5.743L10 14l-1 1-1 1H6v2H2v-4l4.257-4.257A6 6 0 1118 8zm-6-4a1 1 0 100 2 2 2 0 012 2 1 1 0 102 0 4 4 0 00-4-4z' clip-rule='evenodd' /%3E%3C/svg%3E");
 }
-input[data-task='u']:checked,
-li[data-task='u'] > input:checked,
-li[data-task='u'] > p > input:checked {
+body.alternative-checkboxes input[data-task='u']:checked,
+body.alternative-checkboxes li[data-task='u'] > input:checked,
+body.alternative-checkboxes li[data-task='u'] > p > input:checked {
   color: var(--color-green);
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath fill-rule='evenodd' d='M12 7a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0V8.414l-4.293 4.293a1 1 0 01-1.414 0L8 10.414l-4.293 4.293a1 1 0 01-1.414-1.414l5-5a1 1 0 011.414 0L11 10.586 14.586 7H12z' clip-rule='evenodd' /%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath fill-rule='evenodd' d='M12 7a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0V8.414l-4.293 4.293a1 1 0 01-1.414 0L8 10.414l-4.293 4.293a1 1 0 01-1.414-1.414l5-5a1 1 0 011.414 0L11 10.586 14.586 7H12z' clip-rule='evenodd' /%3E%3C/svg%3E");
 }
-input[data-task='d']:checked,
-li[data-task='d'] > input:checked,
-li[data-task='d'] > p > input:checked {
+body.alternative-checkboxes input[data-task='d']:checked,
+body.alternative-checkboxes li[data-task='d'] > input:checked,
+body.alternative-checkboxes li[data-task='d'] > p > input:checked {
   color: var(--color-red);
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath fill-rule='evenodd' d='M12 13a1 1 0 100 2h5a1 1 0 001-1V9a1 1 0 10-2 0v2.586l-4.293-4.293a1 1 0 00-1.414 0L8 9.586 3.707 5.293a1 1 0 00-1.414 1.414l5 5a1 1 0 001.414 0L11 9.414 14.586 13H12z' clip-rule='evenodd' /%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath fill-rule='evenodd' d='M12 13a1 1 0 100 2h5a1 1 0 001-1V9a1 1 0 10-2 0v2.586l-4.293-4.293a1 1 0 00-1.414 0L8 9.586 3.707 5.293a1 1 0 00-1.414 1.414l5 5a1 1 0 001.414 0L11 9.414 14.586 13H12z' clip-rule='evenodd' /%3E%3C/svg%3E");
 }
-input[data-task='w']:checked,
-li[data-task='w'] > input:checked,
-li[data-task='w'] > p > input:checked {
+body.alternative-checkboxes input[data-task='w']:checked,
+body.alternative-checkboxes li[data-task='w'] > input:checked,
+body.alternative-checkboxes li[data-task='w'] > p > input:checked {
   color: var(--color-purple);
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath fill-rule='evenodd' d='M6 3a1 1 0 011-1h.01a1 1 0 010 2H7a1 1 0 01-1-1zm2 3a1 1 0 00-2 0v1a2 2 0 00-2 2v1a2 2 0 00-2 2v.683a3.7 3.7 0 011.055.485 1.704 1.704 0 001.89 0 3.704 3.704 0 014.11 0 1.704 1.704 0 001.89 0 3.704 3.704 0 014.11 0 1.704 1.704 0 001.89 0A3.7 3.7 0 0118 12.683V12a2 2 0 00-2-2V9a2 2 0 00-2-2V6a1 1 0 10-2 0v1h-1V6a1 1 0 10-2 0v1H8V6zm10 8.868a3.704 3.704 0 01-4.055-.036 1.704 1.704 0 00-1.89 0 3.704 3.704 0 01-4.11 0 1.704 1.704 0 00-1.89 0A3.704 3.704 0 012 14.868V17a1 1 0 001 1h14a1 1 0 001-1v-2.132zM9 3a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1zm3 0a1 1 0 011-1h.01a1 1 0 110 2H13a1 1 0 01-1-1z' clip-rule='evenodd' /%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath fill-rule='evenodd' d='M6 3a1 1 0 011-1h.01a1 1 0 010 2H7a1 1 0 01-1-1zm2 3a1 1 0 00-2 0v1a2 2 0 00-2 2v1a2 2 0 00-2 2v.683a3.7 3.7 0 011.055.485 1.704 1.704 0 001.89 0 3.704 3.704 0 014.11 0 1.704 1.704 0 001.89 0 3.704 3.704 0 014.11 0 1.704 1.704 0 001.89 0A3.7 3.7 0 0118 12.683V12a2 2 0 00-2-2V9a2 2 0 00-2-2V6a1 1 0 10-2 0v1h-1V6a1 1 0 10-2 0v1H8V6zm10 8.868a3.704 3.704 0 01-4.055-.036 1.704 1.704 0 00-1.89 0 3.704 3.704 0 01-4.11 0 1.704 1.704 0 00-1.89 0A3.704 3.704 0 012 14.868V17a1 1 0 001 1h14a1 1 0 001-1v-2.132zM9 3a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1zm3 0a1 1 0 011-1h.01a1 1 0 110 2H13a1 1 0 01-1-1z' clip-rule='evenodd' /%3E%3C/svg%3E");
 }
-input[data-task='p']:checked,
-li[data-task='p'] > input:checked,
-li[data-task='p'] > p > input:checked {
+body.alternative-checkboxes input[data-task='p']:checked,
+body.alternative-checkboxes li[data-task='p'] > input:checked,
+body.alternative-checkboxes li[data-task='p'] > p > input:checked {
   color: var(--color-green);
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath d='M2 10.5a1.5 1.5 0 113 0v6a1.5 1.5 0 01-3 0v-6zM6 10.333v5.43a2 2 0 001.106 1.79l.05.025A4 4 0 008.943 18h5.416a2 2 0 001.962-1.608l1.2-6A2 2 0 0015.56 8H12V4a2 2 0 00-2-2 1 1 0 00-1 1v.667a4 4 0 01-.8 2.4L6.8 7.933a4 4 0 00-.8 2.4z' /%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath d='M2 10.5a1.5 1.5 0 113 0v6a1.5 1.5 0 01-3 0v-6zM6 10.333v5.43a2 2 0 001.106 1.79l.05.025A4 4 0 008.943 18h5.416a2 2 0 001.962-1.608l1.2-6A2 2 0 0015.56 8H12V4a2 2 0 00-2-2 1 1 0 00-1 1v.667a4 4 0 01-.8 2.4L6.8 7.933a4 4 0 00-.8 2.4z' /%3E%3C/svg%3E");
 }
-input[data-task='c']:checked,
-li[data-task='c'] > input:checked,
-li[data-task='c'] > p > input:checked {
+body.alternative-checkboxes input[data-task='c']:checked,
+body.alternative-checkboxes li[data-task='c'] > input:checked,
+body.alternative-checkboxes li[data-task='c'] > p > input:checked {
   color: var(--color-orange);
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath d='M18 9.5a1.5 1.5 0 11-3 0v-6a1.5 1.5 0 013 0v6zM14 9.667v-5.43a2 2 0 00-1.105-1.79l-.05-.025A4 4 0 0011.055 2H5.64a2 2 0 00-1.962 1.608l-1.2 6A2 2 0 004.44 12H8v4a2 2 0 002 2 1 1 0 001-1v-.667a4 4 0 01.8-2.4l1.4-1.866a4 4 0 00.8-2.4z' /%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath d='M18 9.5a1.5 1.5 0 11-3 0v-6a1.5 1.5 0 013 0v6zM14 9.667v-5.43a2 2 0 00-1.105-1.79l-.05-.025A4 4 0 0011.055 2H5.64a2 2 0 00-1.962 1.608l-1.2 6A2 2 0 004.44 12H8v4a2 2 0 002 2 1 1 0 001-1v-.667a4 4 0 01.8-2.4l1.4-1.866a4 4 0 00.8-2.4z' /%3E%3C/svg%3E");
 }
-input[data-task='b']:checked,
-li[data-task='b'] > input:checked,
-li[data-task='b'] > p > input:checked {
+body.alternative-checkboxes input[data-task='b']:checked,
+body.alternative-checkboxes li[data-task='b'] > input:checked,
+body.alternative-checkboxes li[data-task='b'] > p > input:checked {
   color: var(--color-orange);
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath d='M5 4a2 2 0 012-2h6a2 2 0 012 2v14l-5-2.5L5 18V4z' /%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath d='M5 4a2 2 0 012-2h6a2 2 0 012 2v14l-5-2.5L5 18V4z' /%3E%3C/svg%3E");
 }
-input[data-task='P']:checked,
-li[data-task='P'] > input:checked,
-li[data-task='P'] > p > input:checked {
+body.alternative-checkboxes input[data-task='P']:checked,
+body.alternative-checkboxes li[data-task='P'] > input:checked,
+body.alternative-checkboxes li[data-task='P'] > p > input:checked {
   color: var(--color-green);
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z'%3E%3C/path%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z'%3E%3C/path%3E%3C/svg%3E");
 }
-input[data-task='M']:checked,
-li[data-task='M'] > input:checked,
-li[data-task='M'] > p > input:checked {
+body.alternative-checkboxes input[data-task='M']:checked,
+body.alternative-checkboxes li[data-task='M'] > input:checked,
+body.alternative-checkboxes li[data-task='M'] > p > input:checked {
   color: var(--color-purple);
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M5.45 5.154A4.25 4.25 0 0 0 9.25 7.5h1.378a2.251 2.251 0 1 1 0 1.5H9.25A5.734 5.734 0 0 1 5 7.123v3.505a2.25 2.25 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.95-.218ZM4.25 13.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm8.5-4.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5ZM5 3.25a.75.75 0 1 0 0 .005V3.25Z'%3E%3C/path%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M5.45 5.154A4.25 4.25 0 0 0 9.25 7.5h1.378a2.251 2.251 0 1 1 0 1.5H9.25A5.734 5.734 0 0 1 5 7.123v3.505a2.25 2.25 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.95-.218ZM4.25 13.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm8.5-4.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5ZM5 3.25a.75.75 0 1 0 0 .005V3.25Z'%3E%3C/path%3E%3C/svg%3E");
 }
-input[data-task='D']:checked,
-li[data-task='D'] > input:checked,
-li[data-task='D'] > p > input:checked {
+body.alternative-checkboxes input[data-task='D']:checked,
+body.alternative-checkboxes li[data-task='D'] > input:checked,
+body.alternative-checkboxes li[data-task='D'] > p > input:checked {
   color: var(--color-base-50);
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M3.25 1A2.25 2.25 0 0 1 4 5.372v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.251 2.251 0 0 1 3.25 1Zm9.5 14a2.25 2.25 0 1 1 0-4.5 2.25 2.25 0 0 1 0 4.5ZM2.5 3.25a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0ZM3.25 12a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm9.5 0a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5ZM14 7.5a1.25 1.25 0 1 1-2.5 0 1.25 1.25 0 0 1 2.5 0Zm0-4.25a1.25 1.25 0 1 1-2.5 0 1.25 1.25 0 0 1 2.5 0Z'%3E%3C/path%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M3.25 1A2.25 2.25 0 0 1 4 5.372v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.251 2.251 0 0 1 3.25 1Zm9.5 14a2.25 2.25 0 1 1 0-4.5 2.25 2.25 0 0 1 0 4.5ZM2.5 3.25a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0ZM3.25 12a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm9.5 0a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5ZM14 7.5a1.25 1.25 0 1 1-2.5 0 1.25 1.25 0 0 1 2.5 0Zm0-4.25a1.25 1.25 0 1 1-2.5 0 1.25 1.25 0 0 1 2.5 0Z'%3E%3C/path%3E%3C/svg%3E");
 }
-input[data-task='m']:checked,
-li[data-task='m'] > input:checked,
-li[data-task='m'] > p > input:checked {
+body.alternative-checkboxes input[data-task='m']:checked,
+body.alternative-checkboxes li[data-task='m'] > input:checked,
+body.alternative-checkboxes li[data-task='m'] > p > input:checked {
   color: var(--color-blue);
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M1.75 2h12.5c.966 0 1.75.784 1.75 1.75v8.5A1.75 1.75 0 0 1 14.25 14H1.75A1.75 1.75 0 0 1 0 12.25v-8.5C0 2.784.784 2 1.75 2ZM1.5 12.251c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25V5.809L8.38 9.397a.75.75 0 0 1-.76 0L1.5 5.809v6.442Zm13-8.181v-.32a.25.25 0 0 0-.25-.25H1.75a.25.25 0 0 0-.25.25v.32L8 7.88Z'%3E%3C/path%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M1.75 2h12.5c.966 0 1.75.784 1.75 1.75v8.5A1.75 1.75 0 0 1 14.25 14H1.75A1.75 1.75 0 0 1 0 12.25v-8.5C0 2.784.784 2 1.75 2ZM1.5 12.251c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25V5.809L8.38 9.397a.75.75 0 0 1-.76 0L1.5 5.809v6.442Zm13-8.181v-.32a.25.25 0 0 0-.25-.25H1.75a.25.25 0 0 0-.25.25v.32L8 7.88Z'%3E%3C/path%3E%3C/svg%3E");
 }
-input[data-task='h']:checked,
-li[data-task='h'] > input:checked,
-li[data-task='h'] > p > input:checked {
+body.alternative-checkboxes input[data-task='h']:checked,
+body.alternative-checkboxes li[data-task='h'] > input:checked,
+body.alternative-checkboxes li[data-task='h'] > p > input:checked {
   color: var(--color-red);
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M7.655 14.916v-.001h-.002l-.006-.003-.018-.01a22.066 22.066 0 0 1-3.744-2.584C2.045 10.731 0 8.35 0 5.5 0 2.836 2.086 1 4.25 1 5.797 1 7.153 1.802 8 3.02 8.847 1.802 10.203 1 11.75 1 13.914 1 16 2.836 16 5.5c0 2.85-2.044 5.231-3.886 6.818a22.094 22.094 0 0 1-3.433 2.414 7.152 7.152 0 0 1-.31.17l-.018.01-.008.004a.75.75 0 0 1-.69 0Z'%3E%3C/path%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M7.655 14.916v-.001h-.002l-.006-.003-.018-.01a22.066 22.066 0 0 1-3.744-2.584C2.045 10.731 0 8.35 0 5.5 0 2.836 2.086 1 4.25 1 5.797 1 7.153 1.802 8 3.02 8.847 1.802 10.203 1 11.75 1 13.914 1 16 2.836 16 5.5c0 2.85-2.044 5.231-3.886 6.818a22.094 22.094 0 0 1-3.433 2.414 7.152 7.152 0 0 1-.31.17l-.018.01-.008.004a.75.75 0 0 1-.69 0Z'%3E%3C/path%3E%3C/svg%3E");
 }
-input[data-task='a']:checked,
-li[data-task='a'] > input:checked,
-li[data-task='a'] > p > input:checked {
+body.alternative-checkboxes input[data-task='a']:checked,
+body.alternative-checkboxes li[data-task='a'] > input:checked,
+body.alternative-checkboxes li[data-task='a'] > p > input:checked {
   color: var(--color-orange);
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='currentColor' viewBox='0 0 24 24'%3E%3Cpath fill-rule='evenodd' d='M20 10H4v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8ZM9 13v-1h6v1a1 1 0 0 1-1 1h-4a1 1 0 0 1-1-1Z' clip-rule='evenodd'/%3E%3Cpath d='M2 6a2 2 0 0 1 2-2h16a2 2 0 1 1 0 4H4a2 2 0 0 1-2-2Z'/%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='currentColor' viewBox='0 0 24 24'%3E%3Cpath fill-rule='evenodd' d='M20 10H4v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8ZM9 13v-1h6v1a1 1 0 0 1-1 1h-4a1 1 0 0 1-1-1Z' clip-rule='evenodd'/%3E%3Cpath d='M2 6a2 2 0 0 1 2-2h16a2 2 0 1 1 0 4H4a2 2 0 0 1-2-2Z'/%3E%3C/svg%3E");
 }
-input[data-task='e']:checked,
-li[data-task='e'] > input:checked,
-li[data-task='e'] > p > input:checked {
+body.alternative-checkboxes input[data-task='e']:checked,
+body.alternative-checkboxes li[data-task='e'] > input:checked,
+body.alternative-checkboxes li[data-task='e'] > p > input:checked {
   color: var(--color-yellow);
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24'%3E%3Cpath stroke='currentColor' stroke-width='2' d='M21 12c0 1.2-4.03 6-9 6s-9-4.8-9-6c0-1.2 4.03-6 9-6s9 4.8 9 6Z'/%3E%3Cpath stroke='currentColor' stroke-width='2' d='M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z'/%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24'%3E%3Cpath stroke='currentColor' stroke-width='2' d='M21 12c0 1.2-4.03 6-9 6s-9-4.8-9-6c0-1.2 4.03-6 9-6s9 4.8 9 6Z'/%3E%3Cpath stroke='currentColor' stroke-width='2' d='M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z'/%3E%3C/svg%3E");
 }
-input[data-task='s']:checked,
-li[data-task='s'] > input:checked,
-li[data-task='s'] > p > input:checked {
+body.alternative-checkboxes input[data-task='s']:checked,
+body.alternative-checkboxes li[data-task='s'] > input:checked,
+body.alternative-checkboxes li[data-task='s'] > p > input:checked {
   color: var(--color-blue);
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24'%3E%3Cpath stroke='currentColor' stroke-linecap='round' stroke-width='2' d='m21 21-3.5-3.5M17 10a7 7 0 1 1-14 0 7 7 0 0 1 14 0Z'/%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24'%3E%3Cpath stroke='currentColor' stroke-linecap='round' stroke-width='2' d='m21 21-3.5-3.5M17 10a7 7 0 1 1-14 0 7 7 0 0 1 14 0Z'/%3E%3C/svg%3E");
 }
-input[data-task='r']:checked,
-li[data-task='r'] > input:checked,
-li[data-task='r'] > p > input:checked {
+body.alternative-checkboxes input[data-task='r']:checked,
+body.alternative-checkboxes li[data-task='r'] > input:checked,
+body.alternative-checkboxes li[data-task='r'] > p > input:checked {
   color: var(--color-red);
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M14.064 0h.186C15.216 0 16 .784 16 1.75v.186a8.752 8.752 0 0 1-2.564 6.186l-.458.459c-.314.314-.641.616-.979.904v3.207c0 .608-.315 1.172-.833 1.49l-2.774 1.707a.749.749 0 0 1-1.11-.418l-.954-3.102a1.214 1.214 0 0 1-.145-.125L3.754 9.816a1.218 1.218 0 0 1-.124-.145L.528 8.717a.749.749 0 0 1-.418-1.11l1.71-2.774A1.748 1.748 0 0 1 3.31 4h3.204c.288-.338.59-.665.904-.979l.459-.458A8.749 8.749 0 0 1 14.064 0ZM8.938 3.623h-.002l-.458.458c-.76.76-1.437 1.598-2.02 2.5l-1.5 2.317 2.143 2.143 2.317-1.5c.902-.583 1.74-1.26 2.499-2.02l.459-.458a7.25 7.25 0 0 0 2.123-5.127V1.75a.25.25 0 0 0-.25-.25h-.186a7.249 7.249 0 0 0-5.125 2.123ZM3.56 14.56c-.732.732-2.334 1.045-3.005 1.148a.234.234 0 0 1-.201-.064.234.234 0 0 1-.064-.201c.103-.671.416-2.273 1.15-3.003a1.502 1.502 0 1 1 2.12 2.12Zm6.94-3.935c-.088.06-.177.118-.266.175l-2.35 1.521.548 1.783 1.949-1.2a.25.25 0 0 0 .119-.213ZM3.678 8.116 5.2 5.766c.058-.09.117-.178.176-.266H3.309a.25.25 0 0 0-.213.119l-1.2 1.95ZM12 5a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z'%3E%3C/path%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M14.064 0h.186C15.216 0 16 .784 16 1.75v.186a8.752 8.752 0 0 1-2.564 6.186l-.458.459c-.314.314-.641.616-.979.904v3.207c0 .608-.315 1.172-.833 1.49l-2.774 1.707a.749.749 0 0 1-1.11-.418l-.954-3.102a1.214 1.214 0 0 1-.145-.125L3.754 9.816a1.218 1.218 0 0 1-.124-.145L.528 8.717a.749.749 0 0 1-.418-1.11l1.71-2.774A1.748 1.748 0 0 1 3.31 4h3.204c.288-.338.59-.665.904-.979l.459-.458A8.749 8.749 0 0 1 14.064 0ZM8.938 3.623h-.002l-.458.458c-.76.76-1.437 1.598-2.02 2.5l-1.5 2.317 2.143 2.143 2.317-1.5c.902-.583 1.74-1.26 2.499-2.02l.459-.458a7.25 7.25 0 0 0 2.123-5.127V1.75a.25.25 0 0 0-.25-.25h-.186a7.249 7.249 0 0 0-5.125 2.123ZM3.56 14.56c-.732.732-2.334 1.045-3.005 1.148a.234.234 0 0 1-.201-.064.234.234 0 0 1-.064-.201c.103-.671.416-2.273 1.15-3.003a1.502 1.502 0 1 1 2.12 2.12Zm6.94-3.935c-.088.06-.177.118-.266.175l-2.35 1.521.548 1.783 1.949-1.2a.25.25 0 0 0 .119-.213ZM3.678 8.116 5.2 5.766c.058-.09.117-.178.176-.266H3.309a.25.25 0 0 0-.213.119l-1.2 1.95ZM12 5a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z'%3E%3C/path%3E%3C/svg%3E");
 }
-input[data-task='8']:checked,
-li[data-task='8'] > input:checked,
-li[data-task='8'] > p > input:checked {
+body.alternative-checkboxes input[data-task='8']:checked,
+body.alternative-checkboxes li[data-task='8'] > input:checked,
+body.alternative-checkboxes li[data-task='8'] > p > input:checked {
   color: var(--color-purple);
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M8 6.984c.59-.533 1.204-1.066 1.825-1.493.797-.548 1.7-.991 2.675-.991C14.414 4.5 16 6.086 16 8s-1.586 3.5-3.5 3.5c-.975 0-1.878-.444-2.675-.991-.621-.427-1.235-.96-1.825-1.493-.59.533-1.204 1.066-1.825 1.493-.797.547-1.7.991-2.675.991C1.586 11.5 0 9.914 0 8s1.586-3.5 3.5-3.5c.975 0 1.878.443 2.675.991.621.427 1.235.96 1.825 1.493ZM9.114 8c.536.483 1.052.922 1.56 1.273.704.483 1.3.727 1.826.727 1.086 0 2-.914 2-2 0-1.086-.914-2-2-2-.525 0-1.122.244-1.825.727-.51.35-1.025.79-1.561 1.273ZM3.5 6c-1.086 0-2 .914-2 2 0 1.086.914 2 2 2 .525 0 1.122-.244 1.825-.727.51-.35 1.025-.79 1.561-1.273-.536-.483-1.052-.922-1.56-1.273C4.621 6.244 4.025 6 3.5 6Z'%3E%3C/path%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M8 6.984c.59-.533 1.204-1.066 1.825-1.493.797-.548 1.7-.991 2.675-.991C14.414 4.5 16 6.086 16 8s-1.586 3.5-3.5 3.5c-.975 0-1.878-.444-2.675-.991-.621-.427-1.235-.96-1.825-1.493-.59.533-1.204 1.066-1.825 1.493-.797.547-1.7.991-2.675.991C1.586 11.5 0 9.914 0 8s1.586-3.5 3.5-3.5c.975 0 1.878.443 2.675.991.621.427 1.235.96 1.825 1.493ZM9.114 8c.536.483 1.052.922 1.56 1.273.704.483 1.3.727 1.826.727 1.086 0 2-.914 2-2 0-1.086-.914-2-2-2-.525 0-1.122.244-1.825.727-.51.35-1.025.79-1.561 1.273ZM3.5 6c-1.086 0-2 .914-2 2 0 1.086.914 2 2 2 .525 0 1.122-.244 1.825-.727.51-.35 1.025-.79 1.561-1.273-.536-.483-1.052-.922-1.56-1.273C4.621 6.244 4.025 6 3.5 6Z'%3E%3C/path%3E%3C/svg%3E");
 }
-input[data-task='g']:checked,
-li[data-task='g'] > input:checked,
-li[data-task='g'] > p > input:checked {
+body.alternative-checkboxes input[data-task='g']:checked,
+body.alternative-checkboxes li[data-task='g'] > input:checked,
+body.alternative-checkboxes li[data-task='g'] > p > input:checked {
   color: var(--color-pink);
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M13.637 2.363h-.001l1.676.335c.09.018.164.084.19.173a.25.25 0 0 1-.062.249l-1.373 1.374a.876.876 0 0 1-.619.256H12.31L9.45 7.611A1.5 1.5 0 1 1 6.5 8a1.501 1.501 0 0 1 1.889-1.449l2.861-2.862V2.552c0-.232.092-.455.256-.619L12.88.559a.25.25 0 0 1 .249-.062c.089.026.155.1.173.19Z'%3E%3C/path%3E%3Cpath d='M2 8a6 6 0 1 0 11.769-1.656.751.751 0 1 1 1.442-.413 7.502 7.502 0 0 1-12.513 7.371A7.501 7.501 0 0 1 10.069.789a.75.75 0 0 1-.413 1.442A6.001 6.001 0 0 0 2 8Z'%3E%3C/path%3E%3Cpath d='M5 8a3.002 3.002 0 0 0 4.699 2.476 3 3 0 0 0 1.28-2.827.748.748 0 0 1 1.045-.782.75.75 0 0 1 .445.61A4.5 4.5 0 1 1 8.516 3.53a.75.75 0 1 1-.17 1.49A3 3 0 0 0 5 8Z'%3E%3C/path%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M13.637 2.363h-.001l1.676.335c.09.018.164.084.19.173a.25.25 0 0 1-.062.249l-1.373 1.374a.876.876 0 0 1-.619.256H12.31L9.45 7.611A1.5 1.5 0 1 1 6.5 8a1.501 1.501 0 0 1 1.889-1.449l2.861-2.862V2.552c0-.232.092-.455.256-.619L12.88.559a.25.25 0 0 1 .249-.062c.089.026.155.1.173.19Z'%3E%3C/path%3E%3Cpath d='M2 8a6 6 0 1 0 11.769-1.656.751.751 0 1 1 1.442-.413 7.502 7.502 0 0 1-12.513 7.371A7.501 7.501 0 0 1 10.069.789a.75.75 0 0 1-.413 1.442A6.001 6.001 0 0 0 2 8Z'%3E%3C/path%3E%3Cpath d='M5 8a3.002 3.002 0 0 0 4.699 2.476 3 3 0 0 0 1.28-2.827.748.748 0 0 1 1.045-.782.75.75 0 0 1 .445.61A4.5 4.5 0 1 1 8.516 3.53a.75.75 0 1 1-.17 1.49A3 3 0 0 0 5 8Z'%3E%3C/path%3E%3C/svg%3E");
 }
 
-input[data-task='+']:checked,
-li[data-task='+'] > input:checked,
-li[data-task='+'] > p > input:checked {
+body.alternative-checkboxes input[data-task='+']:checked,
+body.alternative-checkboxes li[data-task='+'] > input:checked,
+body.alternative-checkboxes li[data-task='+'] > p > input:checked {
   --checkbox-marker-color: transparent;
   border-color: var(--color-green);
   background-color: var(--color-green);
   background-size: 100%;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M7.75 2a.75.75 0 0 1 .75.75V7h4.25a.75.75 0 0 1 0 1.5H8.5v4.25a.75.75 0 0 1-1.5 0V8.5H2.75a.75.75 0 0 1 0-1.5H7V2.75A.75.75 0 0 1 7.75 2Z'%3E%3C/path%3E%3C/svg%3E");
 }
-input[data-task='n']:checked,
-li[data-task='n'] > input:checked,
-li[data-task='n'] > p > input:checked {
+body.alternative-checkboxes input[data-task='n']:checked,
+body.alternative-checkboxes li[data-task='n'] > input:checked,
+body.alternative-checkboxes li[data-task='n'] > p > input:checked {
   --checkbox-marker-color: transparent;
   border-color: var(--color-red);
   background-color: var(--color-red);
@@ -2180,37 +2181,37 @@ li[data-task='n'] > p > input:checked {
 }
 
 
-body:not(.tasks) li[data-task='>'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='<'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='b'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='i'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='*'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='!'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='S'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='?'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='/'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='"'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='l'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='I'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='p'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='c'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='f'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='k'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='w'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='u'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='d'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='P'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='M'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='D'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='m'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='h'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='a'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='e'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='s'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='r'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='8'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='+'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='n'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='g'].task-list-item.is-checked {
+body.alternative-checkboxes:not(.tasks) li[data-task='>'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='<'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='b'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='i'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='*'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='!'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='S'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='?'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='/'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='"'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='l'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='I'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='p'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='c'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='f'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='k'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='w'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='u'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='d'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='P'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='M'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='D'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='m'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='h'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='a'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='e'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='s'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='r'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='8'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='+'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='n'].task-list-item.is-checked,
+body.alternative-checkboxes:not(.tasks) li[data-task='g'].task-list-item.is-checked {
     color: var(--text-normal);
 }


### PR DESCRIPTION
This implements the feature mentioned in this issue: https://github.com/rivea0/obsidian-prime/issues/7

- I've implemented the toggle feature in Style Settings.
- By default, your Alternative Checkbox styling is applied and the toggle can disable it.

Once toggled to disable, the Alternative Checkboxes are reset to default styling:
![image](https://github.com/user-attachments/assets/eeef78d8-2ea6-4710-a38c-fe0aa70af797)